### PR TITLE
pdf zones géo modification + string dep principal

### DIFF
--- a/public/pdf/zones_geographiques.ejs
+++ b/public/pdf/zones_geographiques.ejs
@@ -91,7 +91,7 @@ p{
 
 
 .content_zone>li{
-    width : 40%;
+    width : 42%;
     padding : 0 25px;
     clear : none;
     display : inline-block;
@@ -125,7 +125,7 @@ p{
 .deps_com{  
     display: inline-block;
 
-width : 70%;
+width : 50%;
 }
 
 .dep{

--- a/routes/pdf.js
+++ b/routes/pdf.js
@@ -228,7 +228,7 @@ router.get('/zones-geographiques.pdf', async (req, res) => {
                             // conversion en objet classique
                             vendeurs = vendeurs.map(vendeur => {
                                 // mise en tête du département principal du vendeur
-                                vendeur.User.dep = vendeur.User.dep.toString()
+                                vendeur.User.dep = Number(vendeur.User.dep) < 10 ? `0${vendeur.User.dep.toString()}` : vendeur.User.dep.toString()
                                 const listeDeps = vendeur.deps.split(',')
                                 // retrait du département principal
                                 listeDeps.splice(listeDeps.indexOf(vendeur.User.dep), 1)


### PR DESCRIPTION
pdf zones géo modification css pour affichage deps et nom, lors de récup des données conversion en string pour le dep principal et ajout du zéro initial lorsqu'inférieur à 10